### PR TITLE
Prevent empty string from being passed to getElementById() when the r…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -539,7 +539,7 @@ export default function (Alpine) {
 
 		// show templates added programmatically
 		if (route.template && route.programmaticTemplate) {
-			let target = document.getElementById(route.templateTargetId) ?? document.getElementById(PineconeRouter.settings.templateTargetId)
+			let target = route.templateTargetId ? document.getElementById(route.templateTargetId) : document.getElementById(PineconeRouter.settings.templateTargetId);
 			if (cachedTemplates[route.template]) {
 				target.innerHTML = cachedTemplates[route.template]
 				endLoading()


### PR DESCRIPTION
…oute does not have own templateId

- Improved the logic to ensure `route.templateTargetId` is valid before calling `getElementById()`.
- Added a fallback to `PineconeRouter.settings.templateTargetId` if `route.templateTargetId` is not provided.
- This fix ensures that the correct template target is retrieved, preventing potential runtime errors.